### PR TITLE
Added Support for VS Code-Insiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Add recent workspaces of various VSCode variants to Gnome search.
 - Code OSS (Arch Linux)
 - VSCodium
 - Office Visual Studio Code packages
+- Visual Studio Code Insiders
 
 Under the hood this is a small systemd user service which implements the [search provider][1] DBus API and exposes recent workspaces from VSCode.
 

--- a/providers/de.swsnr.VSCodeSearchProvider.code-insiders.ini
+++ b/providers/de.swsnr.VSCodeSearchProvider.code-insiders.ini
@@ -1,0 +1,5 @@
+[Shell Search Provider]
+DesktopId=code-insiders.desktop
+BusName=de.swsnr.VSCodeSearchProvider
+ObjectPath=/de/swsnr/VSCodeSearchProvider/code_insiders
+Version=2

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 config_directory_name: "VSCodium",
             }),
         )?
+        .serve_at(
+            "/de/swsnr/VSCodeSearchProvider/code_insiders",
+            SearchProvider::new(CodeVariant {
+                app_id: "code-insiders",
+                config_directory_name: "Code - Insiders",
+            }),
+        )?
         .build()
         .await?;
     info!("Connected to bus, serving search provider");


### PR DESCRIPTION
This PR adds support for Visual Studio Code Insiders by:

- Adding a new search provider configuration file
- Registering the VS Code Insiders search provider in the main code